### PR TITLE
Fix #24: move biome creation after all blocks have been registered

### DIFF
--- a/src/main/java/draylar/horizon/MinersHorizon.java
+++ b/src/main/java/draylar/horizon/MinersHorizon.java
@@ -1,12 +1,12 @@
 package draylar.horizon;
 
 import draylar.horizon.config.MinersHorizonConfig;
-import draylar.horizon.registry.HorizonBiomes;
 import draylar.horizon.registry.HorizonBlocks;
 import draylar.horizon.registry.HorizonWorld;
 import draylar.horizon.util.HorizonPortalHelper;
 import draylar.omegaconfig.OmegaConfig;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.object.builder.v1.world.poi.PointOfInterestHelper;
 import net.minecraft.item.ItemStack;
@@ -31,9 +31,6 @@ public class MinersHorizon implements ModInitializer {
         // Register ores from config
         HorizonWorld.registerOreHandlers();
 
-        // Load biomes after ores are loaded
-        HorizonBiomes.init();
-
         // The following callback is used for portal activation via any Pickaxe.
         UseBlockCallback.EVENT.register((player, world, hand, blockHitResult) -> {
             if(!world.isClient) {
@@ -48,6 +45,8 @@ public class MinersHorizon implements ModInitializer {
 
             return ActionResult.PASS;
         });
+
+        ServerLifecycleEvents.SERVER_STARTING.register(ms -> HorizonWorld.ensureBlocksAreRegistered());
     }
 
     public static Identifier id(String path) {

--- a/src/main/java/draylar/horizon/MinersHorizonClient.java
+++ b/src/main/java/draylar/horizon/MinersHorizonClient.java
@@ -4,6 +4,7 @@ import draylar.horizon.registry.HorizonBlocks;
 import draylar.horizon.registry.HorizonWorld;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.ColorProviderRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.Material;
@@ -19,6 +20,8 @@ public class MinersHorizonClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
+        ClientLifecycleEvents.CLIENT_STARTED.register(mc -> HorizonWorld.ensureBlocksAreRegistered());
+
         BlockRenderLayerMap.INSTANCE.putBlock(HorizonBlocks.HORIZON_PORTAL, RenderLayer.getTranslucent());
 
         // Register a color provider for stone/ore blocks.

--- a/src/main/java/draylar/horizon/registry/HorizonBiomes.java
+++ b/src/main/java/draylar/horizon/registry/HorizonBiomes.java
@@ -17,7 +17,6 @@ import net.minecraft.world.gen.feature.DefaultBiomeFeatures;
 
 public class HorizonBiomes {
 
-    private static final Biome ROCKY_PLAINS = createRockyPlains();
     public static final RegistryKey<Biome> ROCKY_PLAINS_KEYS = RegistryKey.of(Registry.BIOME_KEY, MinersHorizon.id("rocky_plains"));
 
     private HorizonBiomes() {
@@ -25,7 +24,7 @@ public class HorizonBiomes {
     }
 
     public static void init() {
-        Registry.register(BuiltinRegistries.BIOME, ROCKY_PLAINS_KEYS.getValue(), ROCKY_PLAINS);
+        Registry.register(BuiltinRegistries.BIOME, ROCKY_PLAINS_KEYS.getValue(), createRockyPlains());
     }
 
     public static Biome createRockyPlains() {


### PR DESCRIPTION
Also added a hard crash in case some blocks are missing (otherwise, the biome won't be registered... leading to a harder to debug crash down the line).